### PR TITLE
Change README header to match repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fript-api
+# fript-web
 
 ## Local development
 


### PR DESCRIPTION
I'm suspecting the repo was once called “fript-api” (especially since https://github.com/whirlwin/fript-api redirects to https://github.com/whirlwin/fript-web), but that you forgot to change the name in the README. So I did it for you. :grimacing: 